### PR TITLE
Add defimition sharing

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "harlaw",
-  "version": "1.0.2",
+  "version": "1.0.3",
   "description": "Transform DSL (Lingvo Dictionary File) files to JSON. Formatting options available for custom output.",
   "main": "index.js",
   "repository": "https://github.com/stscoundrel/harlaw.git",

--- a/src/services/formatter.js
+++ b/src/services/formatter.js
@@ -25,7 +25,7 @@ const format = (data, userSettings = null) => {
   const words = []
   let index = 0
 
-  data.forEach((line) => {
+  data.forEach((line, lineIndex) => {
     const startsWith = line.charAt(0)
 
     // Skip metadata lines.
@@ -39,6 +39,26 @@ const format = (data, userSettings = null) => {
       words[index - 1].definitions.push(definition)
 
       return
+    }
+    /**
+       * Check if previous entry is empty -> DSL files group definitions together oddly.
+       * The real definition may be in following entries.
+       */
+    if (words.length > 0) {
+      if (words[index - 1].definitions.length === 0) {
+        let notFound = true
+        let newIndex = lineIndex
+
+        while (notFound) {
+          newIndex += 1
+
+          if (data[newIndex].charAt(0) === TAB) {
+            const foundDefinition = formatLine(data[newIndex], settings)
+            words[index - 1].definitions.push(foundDefinition)
+            notFound = false
+          }
+        }
+      }
     }
 
     // The line is a headword, start new entry.

--- a/tests/fixtures/dsl/TestDictionaryGrouped.dsl
+++ b/tests/fixtures/dsl/TestDictionaryGrouped.dsl
@@ -1,0 +1,12 @@
+#NAME	"Test Dictionary for testing purposes"
+#INDEX_LANGUAGE	"JavaScript"
+#CONTENTS_LANGUAGE	"English"
+fooNeedsDefFromFoo
+AnotherFooNeedsDefFroo
+foo
+	[m1]Lorem ipsum dolor sit amet, [i]dolor[/i] sit igitur[/m]
+bar
+	[m1][b]Dolor[/b] sit igitur.[/m]
+	[m2]Lorem ipsum dolor sit amet.[/m]
+baz
+	[m1]Lorem ipsum dolor sit amet, consectetur adipiscing elit, sed do eiusmod tempor incididunt ut labore et dolore magna aliqua[/m]

--- a/tests/fixtures/json/groupedTestDictionary.json
+++ b/tests/fixtures/json/groupedTestDictionary.json
@@ -1,0 +1,33 @@
+[
+  {
+    "definitions": [
+      "Lorem ipsum dolor sit amet, <i>dolor</i> sit igitur"
+    ],
+    "word": "fooNeedsDefFromFoo"
+  },
+  {
+    "definitions": [
+      "Lorem ipsum dolor sit amet, <i>dolor</i> sit igitur"
+    ],
+    "word": "AnotherFooNeedsDefFroo"
+  },
+  {
+    "definitions": [
+      "Lorem ipsum dolor sit amet, <i>dolor</i> sit igitur"
+    ],
+    "word": "foo"
+  },
+  {
+    "definitions": [
+      "<strong>Dolor</strong> sit igitur.",
+      "Lorem ipsum dolor sit amet."
+    ],
+    "word": "bar"
+  },
+  {
+    "definitions": [
+      "Lorem ipsum dolor sit amet, consectetur adipiscing elit, sed do eiusmod tempor incididunt ut labore et dolore magna aliqua"
+    ],
+    "word": "baz"
+  }
+]

--- a/tests/harlaw.test.js
+++ b/tests/harlaw.test.js
@@ -2,16 +2,19 @@ const fs = require('fs')
 const { toJson, toArray, noMarkupSettings } = require('../index.js')
 
 const inputFile = `${__dirname}/fixtures/dsl/testDictionary.dsl`
+const inputFileGrouped = `${__dirname}/fixtures/dsl/testDictionaryGrouped.dsl`
 const outputFile = `${__dirname}/fixtures/json/TEST_OUTPUT.json`
 
 describe('DSL to array', () => {
   const defaultOutputFile = `${__dirname}/fixtures/json/defaultTestDictionary.json`
   const noMarkupOutputFile = `${__dirname}/fixtures/json/noMarkupTestDictionary.json`
   const customSettingsOutputFile = `${__dirname}/fixtures/json/customTestDictionary.json`
+  const groupedOutputFile = `${__dirname}/fixtures/json/groupedTestDictionary.json`
 
   const expectedDefaultOutput = JSON.parse(fs.readFileSync(defaultOutputFile))
   const expectedNoMarkupOutput = JSON.parse(fs.readFileSync(noMarkupOutputFile))
   const expectedCustomSettingsOutput = JSON.parse(fs.readFileSync(customSettingsOutputFile))
+  const expectedGroupedOutputFile = JSON.parse(fs.readFileSync(groupedOutputFile))
 
   test('Default settings: matches expected json output', async () => {
     const result = await toArray(inputFile)
@@ -23,6 +26,11 @@ describe('DSL to array', () => {
     const result = await toArray(inputFile, noMarkupSettings)
 
     expect(result).toMatchObject(expectedNoMarkupOutput)
+  })
+
+  test('Shared definitions: uses same definition, if DSL is grouped.', async () => {
+    const result = await toArray(inputFileGrouped)
+    expect(result).toMatchObject(expectedGroupedOutputFile)
   })
 
   test('Custom settings: matches expected json output', async () => {


### PR DESCRIPTION
DSL files may have empty definitions for entries. This means the definition is stored in the following entry. Essentially if 7 entries have identical definition, they are grouped together with first 6 being empty.

When facing empty defs, dig them from down the line